### PR TITLE
upgrade node-sass to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "hexo": ">= 1.0.0"
   },
   "dependencies": {
-    "node-sass": "~0.5.3"
+    "node-sass": "~0.7.0"
   }
 }


### PR DESCRIPTION
after node-sass v0.7.0 hexo gets a wired `TypeError: undefined is not a function` when node-sass is called.  
I wasn't able to find the cause of the error.
