### PR TITLE
Use the theme config

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ var extend = require('util')._extend;
 
 var sassRenderer = function(data, options) {
 
-  var config = extend({
+  var config = {
     data: data.text,
     file: data.path,
     outputStyle: 'nested',
     sourceComments: false,
-  }, hexo.config.node_sass || {});
+  };
+  config = extend(config, hexo.theme.config.node_sass || {});
+  config = extend(config, hexo.config.node_sass || {});
 
   try {
     // node-sass result object:


### PR DESCRIPTION
Thank you for the good plugin!

I feel it is better to use the theme config, like [hexo-renderer-less](https://github.com/hexojs/hexo-renderer-less.git).
In the global configuration, it would affect the other themes.