### PR TITLE
updated node-sass to work with node v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ var sassRenderer = function(data, options) {
     // node-sass result object:
     // https://github.com/sass/node-sass#result-object
     var result = sass.renderSync(config);
-    return result.css;
+    // result is now Buffer instead of String
+    // https://github.com/sass/node-sass/issues/711
+    return result.css.toString();
   }
   catch(error) {
     console.error(error.toString());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-renderer-sass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Sass renderer plugin for Hexo",
   "main": "index",
   "repository": {
@@ -22,6 +22,6 @@
     "hexo": ">= 1.0.0"
   },
   "dependencies": {
-    "node-sass": "^2.1.1"
+    "node-sass": "^3.2.2"
   }
 }


### PR DESCRIPTION
when using with latest node v4.0.0, node-sass does not works.

node-sass have changed the location of pre-built binaries and building node-sass throws more than dozens of deprecated warnings and errors and fails.

 ```
~/Code/lab/site$  npm install hexo-renderer-sass
npm WARN deprecated pangyp@2.3.2: use node-gyp@3+, it does all the things
\
> node-sass@2.1.1 install /home/vivek/Code/lab/site/node_modules/hexo-renderer-sass/node_modules/node-sass
> node scripts/install.js

Can not download file from https://raw.githubusercontent.com/sass/node-sass-binaries/v2.1.1/linux-x64-node-4.0/binding.node

> node-sass@2.1.1 postinstall /home/vivek/Code/lab/site/node_modules/hexo-renderer-sass/node_modules/node-sass
> node scripts/build.js

make: Entering directory '/home/vivek/Code/lab/site/node_modules/hexo-renderer-sass/node_modules/node-sass/build'
  CXX(target) Release/obj.target/binding/src/binding.o
In file included from ../src/binding.cpp:1:0:
../node_modules/nan/nan.h:324:27: error: redefinition of ‘template<class T> v8::Local<T> Nan::imp::NanEnsureHandleOrPersistent(const v8::Local<T>&)’
   NAN_INLINE v8::Local<T> NanEnsureHandleOrPersistent(const v8::Local<T> &val) {
                           ^
../node_modules/nan/nan.h:319:17: note: ‘template<class T> v8::Handle<T> Nan::imp::NanEnsureHandleOrPersistent(v8::Handle<T>&)’ previously declared here
   v8::Handle<T> NanEnsureHandleOrPersistent(const v8::Handle<T> &val) {
                 ^
../node_modules/nan/nan.h:344:27: error: redefinition of ‘template<class T> v8::Local<T> Nan::imp::NanEnsureLocal(v8::Handle<T>&)’
   NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Handle<T> &val) {
                           ^
../node_modules/nan/nan.h:334:27: note: ‘template<class T> v8::Local<T> Nan::imp::NanEnsureLocal(const v8::Local<T>&)’ previously declared here
   NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Local<T> &val) {
                           ^
../node_modules/nan/nan.h:757:13: error: ‘node::smalloc’ has not been declared
     , node::smalloc::FreeCallback callback
             ^
../node_modules/nan/nan.h:757:35: error: expected ‘,’ or ‘...’ before ‘callback’
     , node::smalloc::FreeCallback callback
                                   ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(char*, size_t, int)’:
../node_modules/nan/nan.h:761:50: error: ‘callback’ was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                  ^
../node_modules/nan/nan.h:761:60: error: ‘hint’ was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                            ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(const char*, uint32_t)’:
../node_modules/nan/nan.h:768:67: error: call of overloaded ‘New(v8::Isolate*, const char*&, uint32_t&)’ is ambiguous
     return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
                                                                   ^
../node_modules/nan/nan.h:768:67: note: candidates are:
In file included from ../node_modules/nan/nan.h:25:0,
                 from ../src/binding.cpp:1:
/home/vivek/.node-gyp/4.0.0/src/node_buffer.h:31:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, v8::Local<v8::String>, node::encoding) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/home/vivek/.node-gyp/4.0.0/src/node_buffer.h:31:40: note:   no known conversion for argument 3 from ‘uint32_t {aka unsigned int}’ to ‘node::encoding’
/home/vivek/.node-gyp/4.0.0/src/node_buffer.h:43:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, char*, size_t) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/home/vivek/.node-gyp/4.0.0/src/node_buffer.h:43:40: note:   no known conversion for argument 2 from ‘const char*’ to ‘char*’
In file included from ../src/binding.cpp:1:0:
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(uint32_t)’:
../node_modules/nan/nan.h:772:61: error: could not convert ‘node::Buffer::New(v8::Isolate::GetCurrent(), ((size_t)size))’ from ‘v8::MaybeLocal<v8::Object>’ to ‘v8::Local<v8::Object>’
     return node::Buffer::New(v8::Isolate::GetCurrent(), size);
                                                             ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanBufferUse(char*, uint32_t)’:
../node_modules/nan/nan.h:779:12: error: ‘Use’ is not a member of ‘node::Buffer’
     return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
            ^
../src/binding.cpp: In function ‘void dispatched_async_uv_callback(uv_async_t*)’:
../src/binding.cpp:70:35: warning: ‘void node::FatalException(const v8::TryCatch&)’ is deprecated (declared at /home/vivek/.node-gyp/4.0.0/src/node.h:282): Use FatalException(isolate, ...) [-Wdeprecated-declarations]
     node::FatalException(try_catch);
                                   ^
../src/binding.cpp: In function ‘void make_callback(uv_work_t*)’:
../src/binding.cpp:245:35: warning: ‘void node::FatalException(const v8::TryCatch&)’ is deprecated (declared at /home/vivek/.node-gyp/4.0.0/src/node.h:282): Use FatalException(isolate, ...) [-Wdeprecated-declarations]
     node::FatalException(try_catch);
                                   ^
../src/binding.cpp: In function ‘void ImportedCallback(const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/binding.cpp:365:35: warning: ‘void node::FatalException(const v8::TryCatch&)’ is deprecated (declared at /home/vivek/.node-gyp/4.0.0/src/node.h:282): Use FatalException(isolate, ...) [-Wdeprecated-declarations]
     node::FatalException(try_catch);
                                   ^
binding.target.mk:128: recipe for target 'Release/obj.target/binding/src/binding.o' failed
make: *** [Release/obj.target/binding/src/binding.o] Error 1
make: Leaving directory '/home/vivek/Code/lab/site/node_modules/hexo-renderer-sass/node_modules/node-sass/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/vivek/Code/lab/site/node_modules/hexo-renderer-sass/node_modules/node-sass/node_modules/pangyp/lib/build.js:272:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 4.1.0-1-amd64
gyp ERR! command "/usr/bin/nodejs" "/home/vivek/Code/lab/site/node_modules/hexo-renderer-sass/node_modules/node-sass/node_modules/pangyp/bin/node-gyp" "rebuild"
gyp ERR! cwd /home/vivek/Code/lab/site/node_modules/hexo-renderer-sass/node_modules/node-sass
gyp ERR! node -v v4.0.0
gyp ERR! pangyp -v v2.3.2
gyp ERR! not ok 
Build failed
hexo-renderer-sass@0.1.2 node_modules/hexo-renderer-sass
└── node-sass@2.1.1 (get-stdin@4.0.1, object-assign@2.1.1, replace-ext@0.0.1, shelljs@0.3.0, semver@4.3.6, nan@1.9.0, mkdirp@0.5.1, cross-spawn@0.2.9, chalk@0.5.1, npmconf@2.1.2, meow@3.3.0, gaze@0.5.1, sass-graph@1.3.0, pangyp@2.3.2, request@2.61.0, mocha@2.3.2)
```