### PR TITLE
add hexo to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "type": "MIT",
     "url": "https://raw.github.com/tommy351/hexo/master/LICENSE"
   },
-  "engines": {
-    "hexo": ">= 1.0.0"
-  },
   "dependencies": {
     "node-sass": "^3.2.2"
+  },
+  "peerDependencies": {
+    "hexo": ">= 1.0.0"
   }
 }


### PR DESCRIPTION
This PR solves warnings from yarn: 

> The engine "hexo" appears to be invalid.