### PR TITLE
Use standard code style

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-coverage

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "env": {
-    "node": true
-  },
-  "extends": "eslint:recommended",
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 # - https://github.com/hexojs/hexo/blob/master/.travis.yml
 # - https://github.com/sass/node-sass/blob/master/.travis.yml
 node_js:
-  - "0.12"
   - "4"
   - "6"
   - "7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ node_js:
   - "7"
 
 script:
-  - npm run eslint
+  - npm run lint
   - npm run test-cov
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@ node_js:
   - "4"
   - "6"
   - "7"
+env:
+- CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
 
 script:
   - npm run lint

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 /* global hexo */
-'use strict';
+'use strict'
 
-var sassRenderer = require('./lib/renderer');
+var sassRenderer = require('./lib/renderer')
 
 // associate the Sass renderer with .scss AND .sass extensions
-hexo.extend.renderer.register('scss', 'css', sassRenderer);
-hexo.extend.renderer.register('sass', 'css', sassRenderer);
+hexo.extend.renderer.register('scss', 'css', sassRenderer)
+hexo.extend.renderer.register('sass', 'css', sassRenderer)

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,34 +1,32 @@
 /* global hexo */
-'use strict';
+'use strict'
 
-var sass   = require('node-sass');
-var extend = require('util')._extend;
+var sass = require('node-sass')
+var extend = require('util')._extend
 
-module.exports = function(data) {
-
+module.exports = function (data) {
     // support global and theme-specific config
-    var userConfig = extend(
+  var userConfig = extend(
         hexo.theme.config.node_sass || {},
         hexo.config.node_sass || {}
-    );
+    )
 
-    var config = extend({
-        data: data.text,
-        file: data.path,
-        outputStyle: 'nested',
-        sourceComments: false,
-    }, userConfig);
+  var config = extend({
+    data: data.text,
+    file: data.path,
+    outputStyle: 'nested',
+    sourceComments: false
+  }, userConfig)
 
-    try {
+  try {
         // node-sass result object:
         // https://github.com/sass/node-sass#result-object
-        var result = sass.renderSync(config);
+    var result = sass.renderSync(config)
         // result is now Buffer instead of String
         // https://github.com/sass/node-sass/issues/711
-        return result.css.toString();
-    }
-    catch(error) {
-        console.error(error.toString());
-        throw error;
-    }
-};
+    return result.css.toString()
+  } catch (error) {
+    console.error(error.toString())
+    throw error
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://raw.github.com/tommy351/hexo/master/LICENSE"
   },
   "scripts": {
-    "eslint": "eslint .",
+    "lint": "standard",
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js"
   },
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.12.2",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "standard": "^8.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js"
   },
+  "engines": {
+    "node": ">= 4"
+  },
   "dependencies": {
     "node-sass": "^4.1.1"
   },

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "env": {
-    "mocha": true
-  },
-  "extends": "../.eslintrc"
-}

--- a/test/index.js
+++ b/test/index.js
@@ -1,83 +1,84 @@
-'use strict';
+'use strict'
+
+/* eslint-env mocha */
 
 var should = require('chai').should(); // eslint-disable-line
 
-describe('Sass renderer', function() {
-    var ctx = {
-        config: {},
-        theme: {
-            config: {}
-        }
-    };
+describe('Sass renderer', function () {
+  var ctx = {
+    config: {},
+    theme: {
+      config: {}
+    }
+  }
 
-    global.hexo = ctx;
+  global.hexo = ctx
 
-    var r = require('../lib/renderer');
+  var r = require('../lib/renderer')
 
-    it('default', function () {
-        var body = [
-            '$color: red;',
-            '.foo {',
-            '  color: $color;',
-            '}'
-        ].join('\n');
+  it('default', function () {
+    var body = [
+      '$color: red;',
+      '.foo {',
+      '  color: $color;',
+      '}'
+    ].join('\n')
 
-        var result = r({ text: body }, {});
-        result.should.eql([
-                '.foo {',
-                '  color: red; }'
-            ].join('\n') + '\n');
-    });
+    var result = r({ text: body }, {})
+    result.should.eql([
+      '.foo {',
+      '  color: red; }'
+    ].join('\n') + '\n')
+  })
 
-    it('outputStyle compressed', function () {
+  it('outputStyle compressed', function () {
+    ctx.theme.config = { node_sass: { outputStyle: 'compressed' } }
+    global.hexo = ctx
 
-        ctx.theme.config = { node_sass: { outputStyle: 'compressed' } };
-        global.hexo = ctx;
+    var body = [
+      '$color: red;',
+      '.foo {',
+      '  color: $color;',
+      '}'
+    ].join('\n')
 
-        var body = [
-            '$color: red;',
-            '.foo {',
-            '  color: $color;',
-            '}'
-        ].join('\n');
+    var result = r({ text: body }, {})
+    result.should.eql([
+      '.foo{color:red}'
+    ].join('\n') + '\n')
+  })
 
-        var result = r({ text: body }, {});
-        result.should.eql([
-                '.foo{color:red}'
-            ].join('\n') + '\n');
-    });
+  it('supports root config', function () {
+    ctx.config = { node_sass: { outputStyle: 'compressed' } }
+    ctx.theme.config = {}
+    global.hexo = ctx
 
-    it('supports root config', function () {
-        ctx.config = { node_sass: { outputStyle: 'compressed' } };
-        ctx.theme.config = {};
-        global.hexo = ctx;
+    var body = [
+      '$color: red;',
+      '.foo {',
+      '  color: $color;',
+      '}'
+    ].join('\n')
 
-        var body = [
-            '$color: red;',
-            '.foo {',
-            '  color: $color;',
-            '}'
-        ].join('\n');
+    var result = r({ text: body }, {})
+    result.should.eql([
+      '.foo{color:red}'
+    ].join('\n') + '\n')
+  })
 
-        var result = r({ text: body }, {});
-        result.should.eql([
-                '.foo{color:red}'
-            ].join('\n') + '\n');
-    });
+  it('throw when error occurs', function () {
+    ctx.theme.config = { node_sass: { outputStyle: 'compressed' } }
+    ctx.config = {}
+    global.hexo = ctx
 
-    it('throw when error occurs', function () {
-        ctx.theme.config = { node_sass: { outputStyle: 'compressed' } };
-        ctx.config = {};
-        global.hexo = ctx;
+    var body = [
+      '.foo {',
+      '  color: $color;',
+      '}'
+    ].join('\n')
 
-        var body = [
-            '.foo {',
-            '  color: $color;',
-            '}'
-        ].join('\n');
-
-        should.Throw(function () {
-            return r({ text: body }, {})
-        });
+    should.Throw(function () {
+      return r({ text: body }, {})
     })
-});
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,7 +6,7 @@ abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-acorn-jsx@^3.0.0:
+acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
@@ -345,6 +345,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+debug-log@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+
 debug@2.2.0, debug@^2.1.1, debug@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -364,6 +368,17 @@ deep-eql@^0.1.3:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+deglob@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/deglob/-/deglob-2.1.0.tgz#4d44abe16ef32c779b4972bd141a80325029a14a"
+  dependencies:
+    find-root "^1.0.0"
+    glob "^7.0.5"
+    ignore "^3.0.9"
+    pkg-config "^1.1.0"
+    run-parallel "^1.1.2"
+    uniq "^1.0.1"
 
 del@^2.0.2:
   version "2.2.2"
@@ -484,9 +499,32 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^3.12.2:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.12.2.tgz#6be5a9aa29658252abd7f91e9132bab1f26f3c34"
+eslint-config-standard-jsx@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-3.2.0.tgz#c240e26ed919a11a42aa4de8059472b38268d620"
+
+eslint-config-standard@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-6.2.1.tgz#d3a68aafc7191639e7ee441e7348739026354292"
+
+eslint-plugin-promise@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.0.tgz#6ba9048c2df57be77d036e0c68918bc9b4fc4195"
+
+eslint-plugin-react@~6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.7.1.tgz#1af96aea545856825157d97c1b50d5a8fb64a5a7"
+  dependencies:
+    doctrine "^1.2.2"
+    jsx-ast-utils "^1.3.3"
+
+eslint-plugin-standard@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-2.0.1.tgz#3589699ff9c917f2c25f76a916687f641c369ff3"
+
+eslint@~3.10.2:
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.10.2.tgz#c9a10e8bf6e9d65651204778c503341f1eac3ce7"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
@@ -499,7 +537,7 @@ eslint@^3.12.2:
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     glob "^7.0.3"
-    globals "^9.14.0"
+    globals "^9.2.0"
     ignore "^3.2.0"
     imurmurhash "^0.1.4"
     inquirer "^0.12.0"
@@ -594,6 +632,10 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+find-root@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -687,6 +729,10 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -725,7 +771,7 @@ glob@^7.0.5, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0:
+globals@^9.2.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
 
@@ -810,6 +856,13 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+home-or-tmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.1"
+
 hosted-git-info@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
@@ -822,7 +875,7 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-ignore@^3.2.0:
+ignore@^3.0.9, ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
 
@@ -1036,6 +1089,13 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+jsx-ast-utils@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz#9ba6297198d9f754594d62e59496ffb923778dd4"
+  dependencies:
+    acorn-jsx "^3.0.1"
+    object-assign "^4.1.0"
+
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
@@ -1193,7 +1253,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3:
+minimist@^1.1.0, minimist@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1360,7 +1420,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -1418,6 +1478,14 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-config@^1.0.1, pkg-config@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pkg-config/-/pkg-config-1.1.1.tgz#557ef22d73da3c8837107766c52eadabde298fe4"
+  dependencies:
+    debug-log "^1.0.0"
+    find-root "^1.0.0"
+    xtend "^4.0.1"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -1578,6 +1646,10 @@ run-async@^0.1.0:
   dependencies:
     once "^1.3.0"
 
+run-parallel@^1.1.2:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.6.tgz#29003c9a2163e01e2d2dfc90575f2c6c1d61a039"
+
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
@@ -1668,6 +1740,29 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+standard-engine@~5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-5.2.0.tgz#400660ae5acce8afd4db60ff2214a9190ad790a3"
+  dependencies:
+    deglob "^2.0.0"
+    find-root "^1.0.0"
+    get-stdin "^5.0.1"
+    home-or-tmp "^2.0.0"
+    minimist "^1.1.0"
+    pkg-config "^1.0.1"
+
+standard@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/standard/-/standard-8.6.0.tgz#635132be7bfb567c2921005f30f9e350e4752aad"
+  dependencies:
+    eslint "~3.10.2"
+    eslint-config-standard "6.2.1"
+    eslint-config-standard-jsx "3.2.0"
+    eslint-plugin-promise "~3.4.0"
+    eslint-plugin-react "~6.7.1"
+    eslint-plugin-standard "~2.0.1"
+    standard-engine "~5.2.0"
 
 stdout-stream@^1.4.0:
   version "1.4.0"
@@ -1818,6 +1913,10 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -1898,7 +1997,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Relates to #23. Replaces custom eslint configs with [`standard`](http://npm.im/standard) and reformats code to be standard compliant.