### PR TITLE
Remove unnecessary data config

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@
 var sassRenderer = require('./lib/renderer')
 
 // associate the Sass renderer with .scss AND .sass extensions
-hexo.extend.renderer.register('scss', 'css', sassRenderer("scss"))
-hexo.extend.renderer.register('sass', 'css', sassRenderer("sass"))
+hexo.extend.renderer.register('scss', 'css', sassRenderer('scss'))
+hexo.extend.renderer.register('sass', 'css', sassRenderer('sass'))

--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@
 var sassRenderer = require('./lib/renderer')
 
 // associate the Sass renderer with .scss AND .sass extensions
-hexo.extend.renderer.register('scss', 'css', sassRenderer)
-hexo.extend.renderer.register('sass', 'css', sassRenderer)
+hexo.extend.renderer.register('scss', 'css', sassRenderer("scss"))
+hexo.extend.renderer.register('sass', 'css', sassRenderer("sass"))

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -12,11 +12,15 @@ module.exports = function (data) {
     )
 
   var config = extend({
-    data: data.path ? null : data.text,
+    data: data.text,
     file: data.path,
     outputStyle: 'nested',
     sourceComments: false
   }, userConfig)
+
+  var sassConfig = extend({
+    indentedSyntax: true
+  }, config)
 
   try {
         // node-sass result object:
@@ -26,7 +30,13 @@ module.exports = function (data) {
         // https://github.com/sass/node-sass/issues/711
     return result.css.toString()
   } catch (error) {
-    console.error(error.toString())
-    throw error
+    // Maybe it's a sass syntax, try to process with sass config.
+    try {
+      var result = sass.renderSync(sassConfig)
+      return result.css.toString()
+    } catch (error) {
+      console.error(error.toString())
+      throw error
+    }
   }
 }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -32,7 +32,7 @@ module.exports = function (data) {
   } catch (error) {
     // Maybe it's a sass syntax, try to process with sass config.
     try {
-      var result = sass.renderSync(sassConfig)
+      result = sass.renderSync(sassConfig)
       return result.css.toString()
     } catch (error) {
       console.error(error.toString())

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -12,6 +12,7 @@ module.exports = function (data) {
     )
 
   var config = extend({
+    data: data.path ? null : data.text,
     file: data.path,
     outputStyle: 'nested',
     sourceComments: false

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -12,7 +12,6 @@ module.exports = function (data) {
     )
 
   var config = extend({
-    data: data.text,
     file: data.path,
     outputStyle: 'nested',
     sourceComments: false

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -16,7 +16,7 @@ module.exports = (ext) => function (data) {
     file: data.path,
     outputStyle: 'nested',
     sourceComments: false,
-    indentedSyntax: (ext === 'sass') ? true : false
+    indentedSyntax: (ext === 'sass')
   }, userConfig)
 
   try {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -4,7 +4,7 @@
 var sass = require('node-sass')
 var extend = require('util')._extend
 
-module.exports = function (data) {
+module.exports = (ext) => function (data) {
     // support global and theme-specific config
   var userConfig = extend(
         hexo.theme.config.node_sass || {},
@@ -15,12 +15,9 @@ module.exports = function (data) {
     data: data.text,
     file: data.path,
     outputStyle: 'nested',
-    sourceComments: false
+    sourceComments: false,
+    indentedSyntax: (ext === 'sass') ? true : false
   }, userConfig)
-
-  var sassConfig = extend({
-    indentedSyntax: true
-  }, config)
 
   try {
         // node-sass result object:
@@ -30,13 +27,7 @@ module.exports = function (data) {
         // https://github.com/sass/node-sass/issues/711
     return result.css.toString()
   } catch (error) {
-    // Maybe it's a sass syntax, try to process with sass config.
-    try {
-      result = sass.renderSync(sassConfig)
-      return result.css.toString()
-    } catch (error) {
-      console.error(error.toString())
-      throw error
-    }
+    console.error(error.toString())
+    throw error
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ describe('Sass renderer', function () {
 
   var r = require('../lib/renderer')
 
-  it('default', function () {
+  it('default: scss syntax', function () {
     var body = [
       '$color: red;',
       '.foo {',
@@ -31,7 +31,21 @@ describe('Sass renderer', function () {
     ].join('\n') + '\n')
   })
 
-  it('outputStyle compressed', function () {
+  it('default: sass syntax', function () {
+    var body = [
+      '$color: red',
+      '.foo',
+      '  color: $color'
+    ].join('\n')
+
+    var result = r({ text: body }, {})
+    result.should.eql([
+      '.foo {',
+      '  color: red; }'
+    ].join('\n') + '\n')
+  })
+
+  it('outputStyle compressed: scss syntax', function () {
     ctx.theme.config = { node_sass: { outputStyle: 'compressed' } }
     global.hexo = ctx
 
@@ -48,7 +62,23 @@ describe('Sass renderer', function () {
     ].join('\n') + '\n')
   })
 
-  it('supports root config', function () {
+  it('outputStyle compressed: sass syntax', function () {
+    ctx.theme.config = { node_sass: { outputStyle: 'compressed' } }
+    global.hexo = ctx
+
+    var body = [
+      '$color: red',
+      '.foo',
+      '  color: $color'
+    ].join('\n')
+
+    var result = r({ text: body }, {})
+    result.should.eql([
+      '.foo{color:red}'
+    ].join('\n') + '\n')
+  })
+
+  it('supports root config: scss syntax', function () {
     ctx.config = { node_sass: { outputStyle: 'compressed' } }
     ctx.theme.config = {}
     global.hexo = ctx
@@ -66,7 +96,24 @@ describe('Sass renderer', function () {
     ].join('\n') + '\n')
   })
 
-  it('throw when error occurs', function () {
+  it('supports root config: sass syntax', function () {
+    ctx.config = { node_sass: { outputStyle: 'compressed' } }
+    ctx.theme.config = {}
+    global.hexo = ctx
+
+    var body = [
+      '$color: red',
+      '.foo',
+      '  color: $color'
+    ].join('\n')
+
+    var result = r({ text: body }, {})
+    result.should.eql([
+      '.foo{color:red}'
+    ].join('\n') + '\n')
+  })
+
+  it('throw when error occurs: scss syntax', function () {
     ctx.theme.config = { node_sass: { outputStyle: 'compressed' } }
     ctx.config = {}
     global.hexo = ctx
@@ -75,6 +122,21 @@ describe('Sass renderer', function () {
       '.foo {',
       '  color: $color;',
       '}'
+    ].join('\n')
+
+    should.Throw(function () {
+      return r({ text: body }, {})
+    })
+  })
+
+  it('throw when error occurs: sass syntax', function () {
+    ctx.theme.config = { node_sass: { outputStyle: 'compressed' } }
+    ctx.config = {}
+    global.hexo = ctx
+
+    var body = [
+      '.foo',
+      '  color: $color'
     ].join('\n')
 
     should.Throw(function () {

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ describe('Sass renderer', function () {
       '}'
     ].join('\n')
 
-    var result = r("scss")({ text: body }, {})
+    var result = r('scss')({ text: body }, {})
     result.should.eql([
       '.foo {',
       '  color: red; }'
@@ -38,7 +38,7 @@ describe('Sass renderer', function () {
       '  color: $color'
     ].join('\n')
 
-    var result = r("sass")({ text: body }, {})
+    var result = r('sass')({ text: body }, {})
     result.should.eql([
       '.foo {',
       '  color: red; }'
@@ -72,7 +72,7 @@ describe('Sass renderer', function () {
       '  color: $color'
     ].join('\n')
 
-    var result = r("sass")({ text: body }, {})
+    var result = r('sass')({ text: body }, {})
     result.should.eql([
       '.foo{color:red}'
     ].join('\n') + '\n')
@@ -107,7 +107,7 @@ describe('Sass renderer', function () {
       '  color: $color'
     ].join('\n')
 
-    var result = r("sass")({ text: body }, {})
+    var result = r('sass')({ text: body }, {})
     result.should.eql([
       '.foo{color:red}'
     ].join('\n') + '\n')
@@ -140,7 +140,7 @@ describe('Sass renderer', function () {
     ].join('\n')
 
     should.Throw(function () {
-      return r("sass")({ text: body }, {})
+      return r('sass')({ text: body }, {})
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ describe('Sass renderer', function () {
       '}'
     ].join('\n')
 
-    var result = r({ text: body }, {})
+    var result = r("scss")({ text: body }, {})
     result.should.eql([
       '.foo {',
       '  color: red; }'
@@ -38,7 +38,7 @@ describe('Sass renderer', function () {
       '  color: $color'
     ].join('\n')
 
-    var result = r({ text: body }, {})
+    var result = r("sass")({ text: body }, {})
     result.should.eql([
       '.foo {',
       '  color: red; }'
@@ -56,7 +56,7 @@ describe('Sass renderer', function () {
       '}'
     ].join('\n')
 
-    var result = r({ text: body }, {})
+    var result = r('scss')({ text: body }, {})
     result.should.eql([
       '.foo{color:red}'
     ].join('\n') + '\n')
@@ -72,7 +72,7 @@ describe('Sass renderer', function () {
       '  color: $color'
     ].join('\n')
 
-    var result = r({ text: body }, {})
+    var result = r("sass")({ text: body }, {})
     result.should.eql([
       '.foo{color:red}'
     ].join('\n') + '\n')
@@ -90,7 +90,7 @@ describe('Sass renderer', function () {
       '}'
     ].join('\n')
 
-    var result = r({ text: body }, {})
+    var result = r('scss')({ text: body }, {})
     result.should.eql([
       '.foo{color:red}'
     ].join('\n') + '\n')
@@ -107,7 +107,7 @@ describe('Sass renderer', function () {
       '  color: $color'
     ].join('\n')
 
-    var result = r({ text: body }, {})
+    var result = r("sass")({ text: body }, {})
     result.should.eql([
       '.foo{color:red}'
     ].join('\n') + '\n')
@@ -125,7 +125,7 @@ describe('Sass renderer', function () {
     ].join('\n')
 
     should.Throw(function () {
-      return r({ text: body }, {})
+      return r('scss')({ text: body }, {})
     })
   })
 
@@ -140,7 +140,7 @@ describe('Sass renderer', function () {
     ].join('\n')
 
     should.Throw(function () {
-      return r({ text: body }, {})
+      return r("sass")({ text: body }, {})
     })
   })
 })


### PR DESCRIPTION
Hello,
This tiny change will fix rendering .sass files by default. The way node-sass works, as stated in its documentation:
> In the case that both file and data options are set, node-sass will give precedence to data

On the other hand, unless the `indentedSyntax` is set to `true` in the options, node-sass will rely on the file extension to determine if the file is `sass` or `scss`. When no file path is specified it defaults to rendering `scss` files which would fail in case data is in sass format.
Providing the data option along with the file option would have no use in this case except for a few hours of debuging and reading the documentations to find out why sass files are failing to get processed.

Also, thank you for putting your valuable time on maintaining this project.