### PR TITLE
Modify node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hexo-renderer-sass",
-  "version": "0.4.0",
-  "description": "Sass renderer plugin for Hexo",
+  "version": "0.4.1",
+  "description": "Sass renderer plugin for Hexo.",
   "main": "index",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "node": ">= 6"
   },
   "dependencies": {
-    "node-sass": "^4.5.3"
+    "node-sass": "^6.0.1"
   },
   "peerDependencies": {
     "hexo": ">= 3"


### PR DESCRIPTION
When I update my node to 16.5.0，the node-sass can't work with it.
Node 16.5 needs node-sass update to 6.0.1，so I modify the version, please merge the request.

thank you very much.